### PR TITLE
Retiring hackme-rtov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,14 +50,6 @@ services:
       websploit:
         ipv4_address: 10.6.6.16
 
-  hackme-rtov:
-    container_name: hackme-rtov
-    image: santosomar/hackme-rtov
-    restart: unless-stopped
-    networks:
-      websploit:
-        ipv4_address: 10.6.6.17
-
   mayhem:
     container_name: mayhem
     image: santosomar/mayhem

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Author: Omar Ωr Santos
 # Web: https://websploit.org
 # Twitter: @santosomar
-# Version: 4.0
+# Version: 4.1
 
 
 clear


### PR DESCRIPTION
This pull request includes two changes: the removal of a service from the `docker-compose.yml` file and a version update in the `install.sh` script.

**Configuration updates:**

* Removed the `hackme-rtov` service configuration from `docker-compose.yml`, including its container name, image, restart policy, and network settings.

**Versioning:**

* Updated the version number in the `install.sh` script from 4.0 to 4.1.

Fixes https://github.com/The-Art-of-Hacking/h4cker/issues/272