### PR TITLE
chore: remove yascon-hackme container from docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,14 +74,6 @@ services:
       websploit:
         ipv4_address: 10.6.6.20
 
-  yascon-hackme:
-    container_name: yascon-hackme
-    image: santosomar/yascon-hackme
-    restart: unless-stopped
-    networks:
-      websploit:
-        ipv4_address: 10.6.6.21
-
   secretcorp-branch1:
     container_name: secretcorp-branch1
     image: santosomar/secretcorp-branch1


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change removes the `yascon-hackme` service configuration, which included its container name, image, restart policy, and network settings.

Fixes #20 