### PR TITLE
docs: add container topology diagram showing websploit network architecture

### DIFF
--- a/container-topology.mmd
+++ b/container-topology.mmd
@@ -1,0 +1,82 @@
+graph TB
+    %% Network definitions
+    subgraph "websploit Network (10.6.6.0/24)"
+        direction TB
+        GW1[Gateway: 10.6.6.1]
+        
+        %% Vulnerable Web Applications
+        subgraph "Vulnerable Web Apps"
+            WG[webgoat<br/>10.6.6.11<br/>santosomar/webgoat]
+            JS[juice-shop<br/>10.6.6.12<br/>santosomar/juice-shop]
+            DVWA[dvwa<br/>10.6.6.13<br/>santosomar/dvwa]
+            MUT[mutillidae_2<br/>10.6.6.14<br/>santosomar/mutillidae_2]
+            DVNA[dvna<br/>10.6.6.15<br/>santosomar/dvna]
+            HAC[hackazon<br/>10.6.6.16<br/>santosomar/hackazon]
+        end
+        
+        %% CTF Challenges
+        subgraph "CTF Challenges"
+            MAY[mayhem<br/>10.6.6.18<br/>santosomar/mayhem]
+            RTV[rtv-safemode<br/>10.6.6.19<br/>santosomar/rtv-safemode]
+            GAL[galactic-archives<br/>10.6.6.20<br/>santosomar/galactic-archives]
+            SEC[secretcorp-branch1<br/>10.6.6.22<br/>santosomar/secretcorp-branch1]
+            GRA[gravemind<br/>10.6.6.23<br/>santosomar/gravemind]
+        end
+        
+        %% DEF CON 30 Challenges
+        subgraph "DEF CON 30"
+            DC30_1[dc30_01<br/>10.6.6.24<br/>santosomar/dc30_01:latest]
+            DC30_2[dc30_02<br/>10.6.6.25<br/>santosomar/dc30_02:latest]
+            YW[y-wing<br/>10.6.6.26<br/>santosomar/ywing:latest]
+        end
+        
+        %% Connect all to gateway
+        GW1 -.-> WG
+        GW1 -.-> JS
+        GW1 -.-> DVWA
+        GW1 -.-> MUT
+        GW1 -.-> DVNA
+        GW1 -.-> HAC
+        GW1 -.-> MAY
+        GW1 -.-> RTV
+        GW1 -.-> GAL
+        GW1 -.-> SEC
+        GW1 -.-> GRA
+        GW1 -.-> DC30_1
+        GW1 -.-> DC30_2
+        GW1 -.-> YW
+    end
+    
+    subgraph "websploit2 Network (10.7.7.0/24)"
+        direction TB
+        GW2[Gateway: 10.7.7.1]
+        
+        %% DEF CON 31 Challenges
+        subgraph "DEF CON 31"
+            DC31_1[dc31_01<br/>10.7.7.21<br/>santosomar/dc31_01:latest]
+            DC31_3[dc31_03<br/>10.7.7.23<br/>santosomar/dc31_03:latest]
+        end
+        
+        %% Connect to gateway
+        GW2 -.-> DC31_1
+        GW2 -.-> DC31_3
+    end
+    
+    %% Host system connection
+    HOST[Host System<br/>Docker Engine]
+    HOST --> GW1
+    HOST --> GW2
+    
+    %% Styling
+    classDef networkBox fill:#e1f5fe,stroke:#01579b,stroke-width:2px
+    classDef gateway fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    classDef webapp fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
+    classDef ctf fill:#e8f5e8,stroke:#1b5e20,stroke-width:2px
+    classDef defcon fill:#fff8e1,stroke:#f57f17,stroke-width:2px
+    classDef host fill:#ffebee,stroke:#c62828,stroke-width:3px
+    
+    class GW1,GW2 gateway
+    class WG,JS,DVWA,MUT,DVNA,HAC webapp
+    class MAY,RTV,GAL,SEC,GRA ctf
+    class DC30_1,DC30_2,YW,DC31_1,DC31_3 defcon
+    class HOST host


### PR DESCRIPTION
This pull request introduces a comprehensive container topology diagram in the `container-topology.mmd` file. The diagram visualizes the network setup, including vulnerable web applications, CTF challenges, DEF CON challenges, and their connections to gateways and the host system. Styling is applied to differentiate elements visually.

### Container Topology Diagram Enhancements:

* **Network Definitions**:
  - Added two subnetworks: `websploit Network (10.6.6.0/24)` and `websploit2 Network (10.7.7.0/24)`, each with its own gateway (`GW1` and `GW2`).

* **Vulnerable Web Applications**:
  - Defined nodes for vulnerable web apps such as `webgoat`, `juice-shop`, `dvwa`, `mutillidae_2`, `dvna`, and `hackazon` under the `websploit Network`.

* **CTF and DEF CON Challenges**:
  - Added nodes for CTF challenges (`mayhem`, `rtv-safemode`, `galactic-archives`, `secretcorp-branch1`, `gravemind`) and DEF CON 30 challenges (`dc30_01`, `dc30_02`, `y-wing`) in the `websploit Network`.
  - Included DEF CON 31 challenges (`dc31_01`, `dc31_03`)