### PR TITLE
chore: add gitignore for Python and MacOS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# MacOS
+.DS_Store
+
+# Python
+__pycache__
+*.pyc
+.venv
+.eggs
+.env
+


### PR DESCRIPTION
adding `.gitignore` for Python and MacOS files