### PR TITLE
chore: update docker-compose.yml source URL to point to the latest ve…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ sudo systemctl enable docker --now
 
 
 echo "[+] Fetching docker-compose.yml from WebSploit.org..."
-wget -O /root/docker-compose.yml https://websploit.org/docker-compose.yml
+wget -O /root/docker-compose.yml https://raw.githubusercontent.com/The-Art-of-Hacking/websploit/refs/heads/master/docker-compose.yml
 
 echo "[+] Starting containers..."
 cd /root


### PR DESCRIPTION
This pull request updates the source URL for downloading the `docker-compose.yml` file in the `install.sh` script to use the raw GitHub content link instead of the previous web address.

- Changed the `wget` command in `install.sh` to fetch `docker-compose.yml` directly from the GitHub repository's raw content URL, ensuring the latest version is always retrieved.