### PR TITLE
bug: add gdb to the list of base packages installed in the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,8 +72,7 @@ fi
 #--------------------------------------------------
 echo "[+] Updating apt and installing base packages..."
 apt update -y
-apt install -y wget curl git ack-grep vim exuberant-ctags python3-pip python3-venv \
-               hostapd ffuf tor jupyter-notebook zaproxy
+apt install -y wget curl git ack-grep gdb vim exuberant-ctags python3-pip python3-venv  hostapd ffuf tor jupyter-notebook zaproxy  
 
 #--------------------------------------------------
 # 3) Install Python-based tools via apt (where possible)


### PR DESCRIPTION
- Fixes #32 

---

This pull request makes a minor update to the `install.sh` script by adding `gdb` to the list of base packages installed via `apt`. This ensures that the GNU Debugger is available in the environment.

- Added `gdb` to the list of packages installed with `apt` in `install.sh` to provide debugging capabilities.