### PR TITLE
fix: make git clone operations idempotent in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,11 +115,26 @@ sudo systemctl enable docker --now
 #--------------------------------------------------
 echo "[+] Cloning GitHub repos..."
 cd /root
-git clone https://github.com/The-Art-of-Hacking/h4cker.git
-git clone https://github.com/danielmiessler/SecLists.git
-git clone https://github.com/internetwache/GitTools.git
-git clone https://github.com/swisskyrepo/PayloadsAllTheThings.git
-git clone https://github.com/The-Art-of-Hacking/websploit.git
+
+# Helper function to clone or update a repo
+clone_or_update() {
+    local repo_url="$1"
+    local dir_name=$(basename "$repo_url" .git)
+    
+    if [ -d "$dir_name" ]; then
+        echo "[*] Directory '$dir_name' already exists. Pulling latest changes..."
+        cd "$dir_name" && git pull && cd ..
+    else
+        echo "[+] Cloning $repo_url..."
+        git clone "$repo_url"
+    fi
+}
+
+clone_or_update https://github.com/The-Art-of-Hacking/h4cker.git
+clone_or_update https://github.com/danielmiessler/SecLists.git
+clone_or_update https://github.com/internetwache/GitTools.git
+clone_or_update https://github.com/swisskyrepo/PayloadsAllTheThings.git
+clone_or_update https://github.com/The-Art-of-Hacking/websploit.git
 
 # IoT firmware exercises for reverse engineering courses
 mkdir -p /root/iot_exercises


### PR DESCRIPTION
Add clone_or_update helper function that checks if the target directory exists before cloning. If the directory exists, it pulls the latest changes instead of failing. This allows the install script to be re-run safely without crashing on existing repositories.

- Fixes #63 

This pull request improves the process of cloning GitHub repositories in the `install.sh` script by introducing a helper function that checks if a repository already exists and updates it if so, instead of always cloning. This makes repeated runs of the script idempotent and prevents unnecessary re-cloning.

**Enhancements to repository management:**

* Added a `clone_or_update` helper function to `install.sh` that checks if a repository directory exists; if it does, the script pulls the latest changes, otherwise it clones the repository.
* Replaced individual `git clone` commands with calls to the new `clone_or_update` function for each required repository, improving script robustness and maintainability.