### PR TITLE
docs: add references sections and proto-pollute to additional-labs README

### DIFF
--- a/additional-labs/README.md
+++ b/additional-labs/README.md
@@ -13,6 +13,7 @@ This directory contains an additional collection of vulnerable web applications 
 | `GraphQL` | `graphql-galaxy` | GraphQL API Hacking |
 | `Multi-Vulnerability-Gauntlet` | `hydra-nexus` | Multiple Vulnerabilities |
 | `Path_Traversal` | `maze-walker` | Path Traversal |
+| `Prototype_Pollution` | `proto-pollute` | Prototype Pollution / DOM Clobbering |
 | `render-reign` | `render-reign` | Server-Side Template Injection (SSTI) |
 | `SQLi` | `sqli-breach` | SQL Injection |
 | `SSRF` | `trojan-relay` | Server-Side Request Forgery |
@@ -48,6 +49,7 @@ The following is the network topology of WebSploit Labs.
 │  ├── render-reign      10.6.6.41                            │
 │  ├── deserial-gate     10.6.6.42                            │
 │  ├── redis-rogue       10.6.6.43                            │
-│  └── graphql-galaxy    10.6.6.44                            │
+│  ├── graphql-galaxy    10.6.6.44                            │
+│  └── proto-pollute     10.6.6.45                            │
 └─────────────────────────────────────────────────────────────┘
 ```

--- a/additional-labs/SQLi/README.md
+++ b/additional-labs/SQLi/README.md
@@ -49,6 +49,7 @@ cursor.execute(query, (username, password))
 ```
 
 ## References
+For more information on SQL Injection vulnerabilities and secure coding practices, check out these resources:
 - [OWASP SQL Injection](https://owasp.org/www-community/attacks/SQL_Injection)
 - **Redefining Hacking: A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
 - **Developing Cybersecurity Programs and Policies in an AI-Driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)

--- a/additional-labs/SSRF/README.md
+++ b/additional-labs/SSRF/README.md
@@ -327,7 +327,7 @@ curl -X POST http://localhost:5012/fetch -d "url=http://127.0.0.1:22"
 
 5. **Detection**: What monitoring strategies would help detect SSRF attacks?
 
-## 📚 Additional Resources
+## 📚 References
 
 - [OWASP Server-Side Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
 - [PortSwigger Web Security - SSRF](https://portswigger.net/web-security/ssrf)
@@ -338,3 +338,15 @@ curl -X POST http://localhost:5012/fetch -d "url=http://127.0.0.1:22"
 - [NIST Cybersecurity Framework](https://www.nist.gov/cybersecurity-framework)
 - [PortSwigger Web Security Academy](https://portswigger.net/web-security-academy)
 
+## Additional References
+
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+- **Build Your Own AI Lab (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/build-your-own/9780135439616)
+- **Defending and Deploying AI (video)** - [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+- **AI-Enabled Programming, Networking, and Cybersecurity** - [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+- **Securing Generative AI** - [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)

--- a/additional-labs/XSS/README.md
+++ b/additional-labs/XSS/README.md
@@ -677,8 +677,8 @@ Comment: <script>
 
 6. **Detection**: How can organizations detect XSS attacks in their applications?
 
-### 📚 Additional Resources
-
+  ### 📚 References
+  To learn more about XSS vulnerabilities and secure coding practices, check out these resources:
 - [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/)
 - [OWASP Top 10 Web Application Security Risks](https://owasp.org/Top10/)
 - [OWASP Web Security Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
@@ -686,3 +686,17 @@ Comment: <script>
 - [OWASP AI Red Teaming & Evaluation](https://genai.owasp.org/initiatives/#ai-redteaming)
 - [NIST Cybersecurity Framework](https://www.nist.gov/cybersecurity-framework)
 - [PortSwigger Web Security Academy](https://portswigger.net/web-security-academy)
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+- **Build Your Own AI Lab (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/build-your-own/9780135439616)
+- **Defending and Deploying AI (video)** - [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+- **AI-Enabled Programming, Networking, and Cybersecurity** - [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+- **Securing Generative AI** - [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)
+- **Redefining Hacking: A Comprehensive Guide to Red Teaming and Bug Bounty Hunting in an AI-driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/redefining-hacking-a/9780138363635/)
+- **Developing Cybersecurity Programs and Policies in an AI-Driven World** - [Available on O'Reilly](https://learning.oreilly.com/library/view/developing-cybersecurity-programs/9780138073992)
+- **Beyond the Algorithm: AI, Security, Privacy, and Ethics** - [Available on O'Reilly](https://learning.oreilly.com/library/view/beyond-the-algorithm/9780138268442)
+- **The AI Revolution in Networking, Cybersecurity, and Emerging Technologies** - [Available on O'Reilly](https://learning.oreilly.com/library/view/the-ai-revolution/9780138293703)

--- a/additional-labs/token-tower/README.md
+++ b/additional-labs/token-tower/README.md
@@ -774,7 +774,8 @@ curl http://localhost:5020/api/admin/flag \
 
 ---
 
-## Additional Resources
+## References
+To learn more about JWT vulnerabilities and secure coding practices, check out these resources:
 
 - **JWT Debugger**: https://jwt.io
 - **jwt_tool**: https://github.com/ticarpi/jwt_tool
@@ -782,10 +783,15 @@ curl http://localhost:5020/api/admin/flag \
 - **PortSwigger JWT Attacks**: https://portswigger.net/web-security/jwt
 - **RFC 7519 (JWT)**: https://datatracker.ietf.org/doc/html/rfc7519
 
----
+## Additional References
 
-## License
-
-This lab is part of WebSploit Labs, created for educational purposes by Omar Santos.
-
-**⚠️ WARNING:** This application contains intentional security vulnerabilities. Use only in controlled lab environments. Never use these techniques against systems without explicit authorization.
+- **Building the Ultimate Cybersecurity Lab and Cyber Range (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/building-the-ultimate/9780138319090/)
+- **Build Your Own AI Lab (video)** - [Available on O'Reilly](https://learning.oreilly.com/course/build-your-own/9780135439616)
+- **Defending and Deploying AI (video)** - [Available on O'Reilly](https://www.oreilly.com/videos/defending-and-deploying/9780135463727/)
+- **AI-Enabled Programming, Networking, and Cybersecurity** - [Available on O'Reilly](https://learning.oreilly.com/course/ai-enabled-programming-networking/9780135402696/)
+- **Securing Generative AI** - [Available on O'Reilly](https://learning.oreilly.com/course/securing-generative-ai/9780135401804/)
+- **The Art of Hacking** - [Visit The Art of Hacking](https://theartofhacking.org)
+- **Hacking Scenarios (Labs) in O'Reilly** - [https://hackingscenarios.com](https://hackingscenarios.com)
+- **GitHub Repository** - [Visit GitHub Repo](https://hackerrepo.org)
+- **WebSploit Labs** - [Visit WebSploit Labs](https://websploit.org)
+- **NetAcad Ethical Hacker Free Course** - [Available (free) on NetAcad Skills for All](https://www.netacad.com/courses/ethical-hacker?courseLang=en-US)


### PR DESCRIPTION
- Fixes #73 

- Add Prototype Pollution lab to directory mapping table and network topology
- Add references intro line to SQLi README
- Add Additional References section to SSRF README with O'Reilly resources
- Rename "Additional Resources" to "References" in XSS README and add O'Reilly links
- Rename "Additional Resources" to "References" in token-tower README and add intro

Standardizes references sections across lab READMEs with consistent formatting and O'Reilly training resources.