### PR TITLE
docs: add additional references to Prototype Pollution README

### DIFF
--- a/additional-labs/Prototype_Pollution/README.md
+++ b/additional-labs/Prototype_Pollution/README.md
@@ -44,6 +44,13 @@ The application is vulnerable to Prototype Pollution because it uses an unsafe r
 The application should use a safe merge function that validates keys and does not allow the attacker to pollute the `Object.prototype`.
 
 ## References
+For more information on prototype pollution and DOM clobbering vulnerabilities and secure coding practices, check out these resources:
+- [WebSploit Labs Prototype Pollution Vulnerability](../../knowledge-base/vulnerabilities/prototype-pollution.md)
+- [WebSploit Labs DOM Clobbering Vulnerability](../../knowledge-base/vulnerabilities/dom-clobbering.md)
+- [WebSploit Labs Prototype Pollution Mitigation](../../knowledge-base/mitigations/prototype-pollution-mitigation.md)
+- [WebSploit Labs DOM Clobbering Mitigation](../../knowledge-base/mitigations/dom-clobbering-mitigation.md)
+
 - [OWASP Prototype Pollution](https://owasp.org/www-community/attacks/Prototype_Pollution)
 - [PortSwigger - Prototype Pollution](https://portswigger.net/web-security/prototype-pollution)
 - [PortSwigger - DOM Clobbering](https://portswigger.net/web-security/dom-based/dom-clobbering)
+


### PR DESCRIPTION
Add links to WebSploit Labs knowledge base documentation:
- Prototype Pollution vulnerability guide
- DOM Clobbering vulnerability guide
- Prototype Pollution mitigation strategies
- DOM Clobbering mitigation strategies
- Fixes #79 


This pull request adds additional resources to the `README.md` for the Prototype Pollution lab, helping developers understand related vulnerabilities and secure coding practices.

Documentation improvements:

* Added links to internal knowledge base articles on prototype pollution and DOM clobbering vulnerabilities, as well as their mitigations, to the `additional-labs/Prototype_Pollution/README.md` file.