### PR TITLE
docs: troubleshooting for Apple Silicon / ARM64 (y-wing under QEMU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Inside an ARM Linux host (e.g., Kali on UTM), register multi-arch handlers befor
 
 ```bash
 sudo docker run --privileged --rm tonistiigi/binfmt --install amd64
-docker compose up -d
+sudo docker compose up -d
 ```
 
 This makes most amd64 containers run, but `y-wing` will still crash because of the Go-runtime issue described above.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ docker compose build --no-cache [container_name]
 
 ### Apple Silicon (M1/M2/M3/M4) and other ARM64 hosts
 
-Several containers in this lab (`webgoat`, `dvwa`, `galactic-archives`, `gravemind`, `y-wing`, `redis-rogue`) are published as `linux/amd64`-only images and run under emulation on ARM64 hosts. Most work fine, but some — notably **`y-wing`** — are Go binaries that crash under QEMU user-mode emulation with errors like:
+Several containers in this lab (`webgoat`, `dvwa`, `galactic-archives`, `gravemind`, `y-wing`, `redis-rogue`) are configured to run as `linux/amd64` and therefore run under emulation on ARM64 hosts. Most work fine, but some — notably **`y-wing`** — are Go binaries that crash under QEMU user-mode emulation with errors like:
 
 ```
 runtime: lfstack.push invalid packing

--- a/README.md
+++ b/README.md
@@ -147,6 +147,58 @@ docker compose build --no-cache [container_name]
 
 ---
 
+## Troubleshooting
+
+### Apple Silicon (M1/M2/M3/M4) and other ARM64 hosts
+
+Several containers in this lab (`webgoat`, `dvwa`, `galactic-archives`, `gravemind`, `y-wing`, `redis-rogue`) are published as `linux/amd64`-only images and run under emulation on ARM64 hosts. Most work fine, but some — notably **`y-wing`** — are Go binaries that crash under QEMU user-mode emulation with errors like:
+
+```
+runtime: lfstack.push invalid packing
+fatal error: lfstack.push
+```
+
+This is a known incompatibility between Go's runtime pointer packing and QEMU's x86-on-ARM emulation. It is not a configuration bug in this repo — see [issue #82](https://github.com/The-Art-of-Hacking/websploit/issues/82).
+
+Pick whichever option fits your setup:
+
+#### Option 1 (recommended for Apple Silicon): Use Docker Desktop with Rosetta 2
+
+Run Docker Desktop directly on macOS (instead of Docker inside a Kali ARM VM) so amd64 emulation goes through Apple's Rosetta 2, which handles Go binaries reliably:
+
+1. Docker Desktop → **Settings → General** → enable **"Use Virtualization framework"**
+2. Docker Desktop → **Settings → General** → enable **"Use Rosetta for x86_64/amd64 emulation on Apple Silicon"**
+3. Restart Docker Desktop, then `docker compose up -d`.
+
+You can still run Kali in a separate VM for the offensive tooling and reach the labs over the network at the documented `10.6.6.x` addresses (or via host-port mappings).
+
+#### Option 2: Run on an x86_64 host
+
+Use the supplied `Vagrantfile` on an Intel/AMD machine, or deploy to any x86_64 cloud VM (AWS, GCP, Azure, DigitalOcean, etc.). No emulation involved, everything works as designed.
+
+#### Option 3: Install QEMU binfmt handlers (helps most amd64 images, not y-wing)
+
+Inside an ARM Linux host (e.g., Kali on UTM), register multi-arch handlers before bringing the stack up:
+
+```bash
+sudo docker run --privileged --rm tonistiigi/binfmt --install amd64
+docker compose up -d
+```
+
+This makes most amd64 containers run, but `y-wing` will still crash because of the Go-runtime issue described above.
+
+#### Option 4: Skip y-wing
+
+If you cannot use options 1–3, start everything except `y-wing`:
+
+```bash
+docker compose up -d $(docker compose config --services | grep -v '^y-wing$')
+```
+
+Or comment out the `y-wing` service block in `docker-compose.yml`. The rest of the labs are independent.
+
+---
+
 ## Disclaimer
 
 > **WARNING**: These applications are **intentionally vulnerable**. They are **NOT malware or malicious**. They are only for educational purposes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,11 @@ services:
         ipv4_address: 10.6.6.23
 
 # Star Wars themed CTF challenge
+# Note: this image is amd64-only. On Apple Silicon / ARM64 hosts the Go runtime
+# inside this container can crash under QEMU emulation ("lfstack.push invalid
+# packing"). See the Troubleshooting section in README.md and issue #82
+# (https://github.com/The-Art-of-Hacking/websploit/issues/82) for workarounds
+# (Rosetta on Docker Desktop, an x86_64 host, or skipping this service).
   y-wing:
     container_name: y-wing
     image: santosomar/ywing:latest


### PR DESCRIPTION
## Summary

Adds a Troubleshooting section to the top-level `README.md` and an inline comment in `docker-compose.yml` documenting the Apple Silicon / ARM64 emulation issue that breaks `y-wing`.

The `santosomar/ywing:latest` image is published as `linux/amd64` only. Under QEMU user-mode emulation on ARM64 hosts (e.g., Kali on UTM on a MacBook M-series), the Go runtime inside the container crashes with:

```
runtime: lfstack.push invalid packing
fatal error: lfstack.push
```

This is a known incompatibility between Go's runtime pointer-packing and QEMU's x86-on-ARM address layout — it is **not** a configuration bug in this repo, and we cannot fix it from the compose file because the image source isn't in this repo. The right long-term fix is a multi-arch (`linux/amd64,linux/arm64`) push of `santosomar/ywing` to Docker Hub. Until then, this PR makes the workarounds discoverable.

Refs #82.

## Changes

- **`README.md`**: new "Troubleshooting → Apple Silicon (M1/M2/M3/M4) and other ARM64 hosts" section listing four ranked options:
  1. Docker Desktop with Rosetta 2 (most reliable on Apple Silicon for amd64 Go binaries)
  2. Run on an x86_64 host (Vagrantfile / any cloud VM)
  3. `tonistiigi/binfmt --install amd64` (helps most amd64 images, but **not** y-wing)
  4. Skip y-wing (one-liner using `docker compose config --services | grep -v`)
- **`docker-compose.yml`**: comment block above the `y-wing` service pointing at the README section and issue #82 so operators see it before they hit the crash.

No service definitions, networks, ports, or images are changed. No vulnerabilities in any lab are altered.

## Test plan

- [x] `docker-compose.yml` parses cleanly (verified with `python3 -c 'import yaml; yaml.safe_load(open(...))'`); all 19 services and the `y-wing` service block are intact.
- [x] Markdown renders correctly in GitHub preview (headings, fenced code, ordered lists).
- [ ] On an Apple Silicon host: confirm Option 1 (Docker Desktop + Rosetta 2) brings `y-wing` up cleanly.
- [ ] On an x86_64 host: confirm `docker compose up -d` continues to work as before (no behavior change expected).

Made with [Cursor](https://cursor.com)